### PR TITLE
Reuse objects between experiments and support override modifier through prefix encoding

### DIFF
--- a/core/src/main/scala/meta/API/SimContainerOptimization.scala
+++ b/core/src/main/scala/meta/API/SimContainerOptimization.scala
@@ -32,7 +32,7 @@ object ContainerFactory {
                     containedAgents ++= agents.map(x => (x.id, x)).toMap
                     addProxyIds(agents.flatMap(x => x.getProxyIds))
                     override def run(msg: List[Message]): (List[Message], Int) = {
-                        var countDown: Int = 0
+                        var localTurns: Int = 0
                         mx = (internalMessages ++ msg).toList.groupBy(_.receiverId)
                         sendMessages.clear()
                         do {
@@ -47,10 +47,10 @@ object ContainerFactory {
                             internalMessages = sendMessages.filter(x => (proxyIds.contains(x.receiverId)))
                             sendMessages --= internalMessages
 
-                            countDown += 1
+                            localTurns += 1
                             mx = internalMessages.toList.groupBy(_.receiverId)
-                        } while (!internalMessages.isEmpty && countDown<kbound)
-                        (sendMessages.toList, countDown)
+                        } while (!internalMessages.isEmpty && localTurns<kbound)
+                        (sendMessages.toList, localTurns)
                     }
                 }
         }

--- a/core/src/main/scala/meta/classLifting/Lifter.scala
+++ b/core/src/main/scala/meta/classLifting/Lifter.scala
@@ -24,9 +24,9 @@ object Lifter {
     assert(names.length==2)
     val class_name = names(0)
     val mtd_name = names(1)
-    val mtd_name_components = mtd_name.split(modifier_separator)
-    val modifierStr = mtd_name_components.filter(recognized_modifiers.contains(_)).mkString(" ")
-    val nameStr = f"${class_name}.${mtd_name_components.filter(!recognized_modifiers.contains(_)).mkString(modifier_separator)}"
+    val mtd_name_components = mtd_name.split(modifier_separator).partition(x => recognized_modifiers.contains(x))
+    val modifierStr = mtd_name_components._1.mkString(" ")
+    val nameStr = f"${class_name}.${mtd_name_components._2.mkString(modifier_separator)}"
     (modifierStr, nameStr)
   }
 }

--- a/core/src/main/scala/meta/classLifting/Lifter.scala
+++ b/core/src/main/scala/meta/classLifting/Lifter.scala
@@ -93,25 +93,29 @@ class Lifter {
 
           mnamess = mtdName :: mnamess
           
-          methodsIdMap = methodsIdMap + (mtdName -> nextId)
-          // Have both symbols pointing to the same impl
-          if (mtdName != raw_mtdName) {
-            mnamess = raw_mtdName :: mnamess
-            methodsIdMap = methodsIdMap + (raw_mtdName -> nextId)
-          }
+          // If both @override and override_ are used, then consider override_ as the constructor
+          // Allow the method body of override_ to replace that of @override, but not the other way
+          if (!(methodsIdMap.get(mtdName).isDefined && mtdName==raw_mtdName)){
+            methodsIdMap = methodsIdMap + (mtdName -> nextId)
+            // Have both symbols pointing to the same impl
+            if (mtdName != raw_mtdName) {
+              mnamess = raw_mtdName :: mnamess
+              methodsIdMap = methodsIdMap + (raw_mtdName -> nextId)
+            }
 
-          val cde: OpenCode[method.A] = method.body.asOpenCode
+            val cde: OpenCode[method.A] = method.body.asOpenCode
 
-          methodsMap = methodsMap + (mtdName -> new MethodInfo(
-            decoded_name._1,
-            mtdName, 
-            method.tparams, 
-            method.vparamss, 
-            cde, 
-            blockingAnalysis(cde, mtdName))(method.A))
-          
-          if (!method.body.toString().contains("this@")) {
-            ssoMtds = mtdName :: ssoMtds 
+            methodsMap = methodsMap + (mtdName -> new MethodInfo(
+              decoded_name._1,
+              mtdName, 
+              method.tparams, 
+              method.vparamss, 
+              cde, 
+              blockingAnalysis(cde, mtdName))(method.A))
+            
+            if (!method.body.toString().contains("this@")) {
+              ssoMtds = mtdName :: ssoMtds 
+            }
           }
       })
 

--- a/core/src/main/scala/meta/deep/codegen/CreateCode.scala
+++ b/core/src/main/scala/meta/deep/codegen/CreateCode.scala
@@ -162,7 +162,7 @@ class CreateCode(initCode: String,
 
     var methodss: String = ""
 
-    val methodCases: String = methodsIdMap.filterNot(x => {x._1.endsWith("handleMessages") || methodsMap(x._1).blocking || x._1.endsWith("main")}).filter(x => x._1.split("\\.").head == actorName).map(x => {
+    val methodCases: String = methodsIdMap.filterNot(x => {x._1.endsWith("handleMessages") || methodsMap.get(x._1).isEmpty || methodsMap(x._1).blocking || x._1.endsWith("main")}).filter(x => x._1.split("\\.").head == actorName).map(x => {
       val foo = methodsMap(x._1)
       methodss += changeTypes(foo.toDeclaration())
       methodss += changeTypes(foo.toWrapperDeclaration())

--- a/core/src/main/scala/meta/deep/codegen/CreateCode.scala
+++ b/core/src/main/scala/meta/deep/codegen/CreateCode.scala
@@ -125,8 +125,9 @@ class CreateCode(initCode: String,
 
     this.typesReplaceWith = ("this@[a-zA-Z0-9]*", "this") :: this.typesReplaceWith
 
-    val initVars: String = changeTypes(rewriteVariables(parts(0).substring(2)) + parts(1))
+    val initVars: String = changeTypes(rewriteVariables(parts(0).substring(2)))
 
+    val stepFunctions: String = changeTypes(parts(1))
 
     // get the reference to memory
     val memAddr: String = parts(1).split(" = ").head.trim().split(" ").find(x => x.startsWith("commands_")).get 
@@ -225,7 +226,7 @@ class CreateCode(initCode: String,
 
     val methods: String = s"${methodss}${run_until}${handleMsg}${gotoHandleMsg}${cloneString}${resetAgentString}"
 
-    createClass(compiledActorGraph.name, parameters, initParams, initVars, methods, parents)
+    createClass(compiledActorGraph.name, parameters, initParams, initVars + stepFunctions, methods, parents)
   }
 
   // given method info, generate string corresponding to method definition
@@ -473,7 +474,7 @@ class CreateCode(initCode: String,
                   run_until: String,
                   parents: String): Unit = {
 
-    val agentName: String = className.split("\\.").last            
+    val agentName: String = className.split("\\.").last
     val classString =
       s"""package ${generatedPackage}
 

--- a/core/src/main/scala/meta/deep/codegen/GeneratedMethods.scala
+++ b/core/src/main/scala/meta/deep/codegen/GeneratedMethods.scala
@@ -96,7 +96,7 @@ case object cloneAgent extends GeneratedMethods {
         s"""
 override def SimClone(): ${actorName} = {
   val newAgent = new ${actorName}(${parameterApplication})
-  ${compiledActorGraph.actorTypes.flatMap(actorType => {
+${compiledActorGraph.actorTypes.flatMap(actorType => {
       actorType.states.filter(x => x.mutable && !x.parameter).map(s => {
         s"  newAgent.${s.name} = ${s.name}"  
       })
@@ -124,21 +124,25 @@ case object resetAgent extends GeneratedMethods {
             })
         })
 
-        if (!mutableVariableNames.isEmpty){
-s"""
+        val systemReset: String = f"${instructionRegister} = 0"
+
+        val userVarsReset: String = 
+            if (!mutableVariableNames.isEmpty){
+                s"val newAgent = new ${actorName}(${parameterApplication})\n" + " "*2 + 
+                compiledActorGraph.actorTypes.flatMap(actorType => {
+                    actorType.states.filter(x => x.mutable && !x.parameter).map(s => {
+                        s"${s.name} = newAgent.${s.name}"  
+                    })
+                }).mkString("\n" + " "*2)
+            } else ""
+
+        s"""
 override def SimReset(): Unit = {
-  val newAgent = new ${actorName}(${parameterApplication})
-${compiledActorGraph.actorTypes.flatMap(actorType => {
-    actorType.states.filter(x => x.mutable && !x.parameter).map(s => {
-        s"  ${s.name} = newAgent.${s.name}"  
-    })
-}).mkString("\n")}
+  ${systemReset}
+  ${userVarsReset}
 }
-"""
-        } else {
-            ""
-        }
-    }
+""" 
+}
 }
 
 case object reflectionMethods extends GeneratedMethods {

--- a/core/src/main/scala/meta/deep/codegen/GeneratedMethods.scala
+++ b/core/src/main/scala/meta/deep/codegen/GeneratedMethods.scala
@@ -98,9 +98,9 @@ override def SimClone(): ${actorName} = {
   val newAgent = new ${actorName}(${parameterApplication})
   ${compiledActorGraph.actorTypes.flatMap(actorType => {
       actorType.states.filter(x => x.mutable && !x.parameter).map(s => {
-        s"newAgent.${s.name} = ${s.name}"  
+        s"  newAgent.${s.name} = ${s.name}"  
       })
-    }).mkString("  \n")}
+    }).mkString("\n")}
   newAgent
 }
 """

--- a/core/src/main/scala/meta/deep/member/MethodInfo.scala
+++ b/core/src/main/scala/meta/deep/member/MethodInfo.scala
@@ -14,13 +14,14 @@ import meta.deep.IR.Predef._
   * @tparam A return value type
   */
 
-class MethodInfo[A0](val symbol: String,
+class MethodInfo[A0](val modifiers: String,
+                    val symbol: String,
                     val tparams: List[IR.TypParam],
                     val vparams: List[List[IR.Variable[_]]], 
                     val body: OpenCode[A0], 
                     val blocking: Boolean)(implicit val A: CodeType[A0]) {
   def replica(newSym: String): MethodInfo[A] = {
-    new MethodInfo[A](newSym, this.tparams, this.vparams, this.body, this.blocking)(A)
+    new MethodInfo[A](modifiers, newSym, this.tparams, this.vparams, this.body, this.blocking)(A)
   }
 
   val mtdName: String = symbol.split("\\.").tail.mkString(".")
@@ -66,20 +67,19 @@ class MethodInfo[A0](val symbol: String,
     argSyms match {
       case None =>
   f"""
-  def ${mtdName}: ${A.rep.toString} =
+  ${modifiers} def ${mtdName}: ${A.rep.toString} =
       ${bodyStr}
-
   """
       case Some(x) =>
   f"""
-  def ${mtdName}(${x.map(p => p._1 + ": " + p._2).mkString(",")}): ${A.rep.toString} = 
+  ${modifiers} def ${mtdName}(${x.map(p => p._1 + ": " + p._2).mkString(",")}): ${A.rep.toString} = 
       ${bodyStr}
   """
     }
   }
 
   def toWrapperInvocation(): String = {
-    f"""wrapper_${mtdName}(args)"""
+    f"wrapper_${mtdName}(args)"
   }
 
   def toInvocation(): String = {
@@ -87,7 +87,7 @@ class MethodInfo[A0](val symbol: String,
       case None =>
         f"${mtdName}"
       case Some(x) =>
-        f"""${mtdName}(${x.map(p => p._1).mkString(",")})"""
+        f"${mtdName}(${x.map(p => p._1).mkString(",")})"
     }
   }
 

--- a/core/src/test/scala/generated/inheritance/InitData.scala
+++ b/core/src/test/scala/generated/inheritance/InitData.scala
@@ -1,0 +1,21 @@
+package generated.meta.test.inheritance
+
+object InitData  {
+    
+        def apply(): scala.`package`.List[meta.runtime.Actor] = {
+  val teacher = new Teacher();
+  val worker = new Worker();
+  scala.collection.immutable.List.apply[meta.test.Person](teacher, worker)
+} 
+        
+        def wrapper(args: List[Any]): List[meta.runtime.Actor] = {
+          apply()
+        }
+        
+        def writeSchema(pw: java.io.PrintWriter): Unit = {
+          pw.write("")
+          pw.flush()
+        }
+        
+        
+}

--- a/core/src/test/scala/generated/inheritance/Teacher.scala
+++ b/core/src/test/scala/generated/inheritance/Teacher.scala
@@ -1,0 +1,239 @@
+package generated.meta.test.inheritance
+
+class Teacher() extends meta.runtime.Actor with meta.test.Person {
+
+
+  private var  reflectionIR_80: Int = -1
+  var resetData_0: scala.Any = null
+  val resetData_1 = scala.collection.mutable.ListBuffer.apply[scala.collection.immutable.List[scala.Tuple2[scala.Tuple2[scala.Int, scala.Int], scala.Int]]]()
+  var resetData_2: meta.runtime.ResponseMessage = null
+  var bindingMut_3: scala.Double = 0.0
+  var bindingMut_4: scala.Any = null
+  var listValMut_5: meta.runtime.RequestMessage = null
+  @transient var iterMut_6: scala.collection.Iterator[meta.runtime.RequestMessage] = null
+  var bindingMut_7: scala.Double = 0.0
+  var unblockFlag_8: scala.Boolean = true
+  var positionVar_9: scala.Int = 0
+  
+  val commands_71 = (() => {
+  val data_10 = new scala.Array[scala.Function0[scala.Unit]](27);
+  data_10.update(0, (() => positionVar_9 = 1));
+  data_10.update(1, (() => {
+    positionVar_9 = 2;
+    val x_11 = scala.Tuple2.apply[scala.Int, scala.Int](-1, -1);
+    val x_12 = scala.Tuple2.apply[scala.Tuple2[scala.Int, scala.Int], scala.Int](x_11, 25);
+    val x_13 = scala.collection.immutable.Nil.::[scala.Tuple2[scala.Tuple2[scala.Int, scala.Int], scala.Int]](x_12);
+    resetData_1.prepend(x_13)
+  }));
+  data_10.update(2, (() => {
+    scala.Predef.println("Teach in a classroom. ");
+    resetData_0 = ();
+    resetData_0 = 0.0;
+    val x_14 = resetData_0;
+    val x_15 = x_14.asInstanceOf[scala.Double];
+    bindingMut_3 = x_15;
+    positionVar_9 = 3
+  }));
+  data_10.update(3, (() => {
+    val x_16 = bindingMut_3;
+    val x_17 = x_16.+(1);
+    resetData_0 = x_17;
+    val x_18 = resetData_0;
+    val x_19 = x_18.asInstanceOf[scala.Double];
+    bindingMut_3 = x_19;
+    positionVar_9 = 4;
+    unblockFlag_8 = false
+  }));
+  data_10.update(4, (() => {
+    val x_20 = bindingMut_3;
+    val x_21 = x_20.<(1.0);
+    if (x_21)
+      positionVar_9 = 3
+    else
+      positionVar_9 = 5
+  }));
+  data_10.update(5, (() => {
+    val x_22 = bindingMut_3;
+    val x_23 = x_22.<(1.0);
+    val x_24 = x_23.`unary_!`;
+    if (x_24)
+      {
+        val x_25 = resetData_1.remove(0);
+        val x_29 = x_25.find(((x_26: scala.Tuple2[scala.Tuple2[scala.Int, scala.Int], scala.Int]) => {
+          val x_27 = x_26._1;
+          val x_28 = scala.Tuple2.apply[scala.Int, scala.Int](-1, -1);
+          x_27.==(x_28)
+        }));
+        val x_30 = x_29.get;
+        val x_31 = x_30._2;
+        positionVar_9 = x_31
+      }
+    else
+      ()
+  }));
+  data_10.update(6, (() => {
+    val x_32 = resetData_0;
+    val x_33 = x_32.asInstanceOf[scala.Any];
+    bindingMut_4 = x_33;
+    val x_34 = bindingMut_4;
+    val x_35 = listValMut_5;
+    x_35.reply(this, x_34);
+    resetData_0 = ();
+    positionVar_9 = 7
+  }));
+  data_10.update(7, (() => positionVar_9 = 8));
+  data_10.update(8, (() => positionVar_9 = 9));
+  data_10.update(9, (() => {
+    val x_36 = iterMut_6;
+    val x_37 = x_36.hasNext;
+    if (x_37)
+      {
+        val x_38 = iterMut_6;
+        val x_39 = x_38.next();
+        listValMut_5 = x_39;
+        positionVar_9 = 10
+      }
+    else
+      positionVar_9 = 14
+  }));
+  data_10.update(10, (() => {
+    val x_40 = listValMut_5;
+    val x_41 = x_40.methodInfo;
+    val x_42 = scala.`package`.Right.apply[scala.Nothing, scala.Int](3);
+    val x_43 = x_41.==(x_42);
+    if (x_43)
+      positionVar_9 = 11
+    else
+      positionVar_9 = 13
+  }));
+  data_10.update(11, (() => positionVar_9 = 12));
+  data_10.update(12, (() => {
+    positionVar_9 = 2;
+    val x_44 = scala.Tuple2.apply[scala.Int, scala.Int](-1, -1);
+    val x_45 = scala.Tuple2.apply[scala.Tuple2[scala.Int, scala.Int], scala.Int](x_44, 6);
+    val x_46 = scala.collection.immutable.Nil.::[scala.Tuple2[scala.Tuple2[scala.Int, scala.Int], scala.Int]](x_45);
+    resetData_1.prepend(x_46)
+  }));
+  data_10.update(13, (() => {
+    val x_47 = listValMut_5;
+    val x_48 = x_47.methodInfo;
+    val x_49 = scala.`package`.Right.apply[scala.Nothing, scala.Int](3);
+    val x_50 = x_48.==(x_49);
+    val x_51 = x_50.`unary_!`;
+    if (x_51)
+      {
+        val x_52 = listValMut_5;
+        val x_53 = scala.collection.immutable.List.apply[meta.runtime.RequestMessage](x_52);
+        val x_54 = this.addReceiveMessages(x_53);
+        resetData_0 = x_54;
+        positionVar_9 = 8
+      }
+    else
+      ()
+  }));
+  data_10.update(14, (() => {
+    val x_55 = iterMut_6;
+    val x_56 = x_55.hasNext;
+    val x_57 = x_56.`unary_!`;
+    if (x_57)
+      positionVar_9 = 15
+    else
+      ()
+  }));
+  data_10.update(15, (() => positionVar_9 = 16));
+  data_10.update(16, (() => {
+    val x_58 = bindingMut_7;
+    val x_59 = x_58.<(1.0);
+    if (x_59)
+      positionVar_9 = 17
+    else
+      positionVar_9 = 20
+  }));
+  data_10.update(17, (() => {
+    val x_60 = bindingMut_7;
+    val x_61 = x_60.+(1);
+    resetData_0 = x_61;
+    val x_62 = resetData_0;
+    val x_63 = x_62.asInstanceOf[scala.Double];
+    bindingMut_7 = x_63;
+    positionVar_9 = 18;
+    unblockFlag_8 = false
+  }));
+  data_10.update(18, (() => positionVar_9 = 19));
+  data_10.update(19, (() => {
+    val x_64 = this.popRequestMessages;
+    val x_65 = x_64.iterator;
+    iterMut_6 = x_65;
+    positionVar_9 = 9
+  }));
+  data_10.update(20, (() => {
+    val x_66 = bindingMut_7;
+    val x_67 = x_66.<(1.0);
+    val x_68 = x_67.`unary_!`;
+    if (x_68)
+      positionVar_9 = 21
+    else
+      ()
+  }));
+  data_10.update(21, (() => positionVar_9 = 1));
+  data_10.update(22, (() => positionVar_9 = 23));
+  data_10.update(23, (() => {
+    positionVar_9 = 24;
+    unblockFlag_8 = false
+  }));
+  data_10.update(24, (() => positionVar_9 = 23));
+  data_10.update(25, (() => {
+    resetData_0 = 0.0;
+    val x_69 = resetData_0;
+    val x_70 = x_69.asInstanceOf[scala.Double];
+    bindingMut_7 = x_70;
+    positionVar_9 = 17
+  }));
+  data_10.update(26, (() => positionVar_9 = 23));
+  data_10
+}).apply();
+  
+
+  override def run(msgs: List[meta.runtime.Message]): (List[meta.runtime.Message], Int) = {
+    addReceiveMessages(msgs)
+    sendMessages.clear()
+    unblockFlag_8 = true
+    while (unblockFlag_8 && (positionVar_9 < 27)) {
+      commands_71(positionVar_9)()
+    }
+    (sendMessages.toList, 1)
+  }
+
+    override def gotoHandleMessages(new_ir: Int = 5): meta.runtime.Actor = {
+      // first entry, save the current IR to reflectionIR
+      unblockFlag_8 = true
+
+      if (reflectionIR_80 == -1){
+        reflectionIR_80 = positionVar_9
+        positionVar_9 = new_ir
+      }
+
+      while (positionVar_9 <= 20 && unblockFlag_8) {
+        commands_71(positionVar_9)()
+      }
+
+      // reset instruction register when finishes processing
+      if (positionVar_9 > 20) {
+        positionVar_9 = reflectionIR_80
+        reflectionIR_80 = -1
+      }
+      this
+    }
+    
+override def SimClone(): Teacher = {
+  val newAgent = new Teacher()
+
+  newAgent
+}
+
+override def SimReset(): Unit = {
+  positionVar_9 = 0
+  
+}
+
+}

--- a/core/src/test/scala/generated/inheritance/Worker.scala
+++ b/core/src/test/scala/generated/inheritance/Worker.scala
@@ -1,0 +1,233 @@
+package generated.meta.test.inheritance
+
+class Worker() extends meta.runtime.Actor with meta.test.Person {
+
+
+  private var  reflectionIR_48: Int = -1
+  var resetData_0: scala.Any = null
+  val resetData_1 = scala.collection.mutable.ListBuffer.apply[scala.collection.immutable.List[scala.Tuple2[scala.Tuple2[scala.Int, scala.Int], scala.Int]]]()
+  var resetData_2: meta.runtime.ResponseMessage = null
+  var bindingMut_3: scala.Any = null
+  var listValMut_4: meta.runtime.RequestMessage = null
+  @transient var iterMut_5: scala.collection.Iterator[meta.runtime.RequestMessage] = null
+  var bindingMut_6: scala.Double = 0.0
+  var unblockFlag_7: scala.Boolean = true
+  var positionVar_8: scala.Int = 0
+  
+  val commands_60 = (() => {
+  val data_9 = new scala.Array[scala.Function0[scala.Unit]](24);
+  data_9.update(0, (() => positionVar_8 = 1));
+  data_9.update(1, (() => {
+    positionVar_8 = 2;
+    val x_10 = scala.Tuple2.apply[scala.Int, scala.Int](-1, -1);
+    val x_11 = scala.Tuple2.apply[scala.Tuple2[scala.Int, scala.Int], scala.Int](x_10, 22);
+    val x_12 = scala.collection.immutable.Nil.::[scala.Tuple2[scala.Tuple2[scala.Int, scala.Int], scala.Int]](x_11);
+    resetData_1.prepend(x_12)
+  }));
+  data_9.update(2, (() => {
+    scala.Predef.println("Work in a factory.");
+    resetData_0 = ();
+    val x_13 = resetData_1.remove(0);
+    val x_17 = x_13.find(((x_14: scala.Tuple2[scala.Tuple2[scala.Int, scala.Int], scala.Int]) => {
+      val x_15 = x_14._1;
+      val x_16 = scala.Tuple2.apply[scala.Int, scala.Int](-1, -1);
+      x_15.==(x_16)
+    }));
+    val x_18 = x_17.get;
+    val x_19 = x_18._2;
+    positionVar_8 = x_19
+  }));
+  data_9.update(3, (() => {
+    val x_20 = resetData_0;
+    val x_21 = x_20.asInstanceOf[scala.Any];
+    bindingMut_3 = x_21;
+    val x_22 = bindingMut_3;
+    val x_23 = listValMut_4;
+    x_23.reply(this, x_22);
+    resetData_0 = ();
+    positionVar_8 = 4
+  }));
+  data_9.update(4, (() => positionVar_8 = 5));
+  data_9.update(5, (() => positionVar_8 = 6));
+  data_9.update(6, (() => {
+    val x_24 = iterMut_5;
+    val x_25 = x_24.hasNext;
+    if (x_25)
+      {
+        val x_26 = iterMut_5;
+        val x_27 = x_26.next();
+        listValMut_4 = x_27;
+        positionVar_8 = 7
+      }
+    else
+      positionVar_8 = 11
+  }));
+  data_9.update(7, (() => {
+    val x_28 = listValMut_4;
+    val x_29 = x_28.methodInfo;
+    val x_30 = scala.`package`.Right.apply[scala.Nothing, scala.Int](0);
+    val x_31 = x_29.==(x_30);
+    if (x_31)
+      positionVar_8 = 8
+    else
+      positionVar_8 = 10
+  }));
+  data_9.update(8, (() => {
+    val x_32 = listValMut_4;
+    this.handleNonblockingMessage(x_32);
+    resetData_0 = ();
+    positionVar_8 = 4
+  }));
+  data_9.update(9, (() => {
+    positionVar_8 = 2;
+    val x_33 = scala.Tuple2.apply[scala.Int, scala.Int](-1, -1);
+    val x_34 = scala.Tuple2.apply[scala.Tuple2[scala.Int, scala.Int], scala.Int](x_33, 3);
+    val x_35 = scala.collection.immutable.Nil.::[scala.Tuple2[scala.Tuple2[scala.Int, scala.Int], scala.Int]](x_34);
+    resetData_1.prepend(x_35)
+  }));
+  data_9.update(10, (() => {
+    val x_36 = listValMut_4;
+    val x_37 = x_36.methodInfo;
+    val x_38 = scala.`package`.Right.apply[scala.Nothing, scala.Int](0);
+    val x_39 = x_37.==(x_38);
+    val x_40 = x_39.`unary_!`;
+    if (x_40)
+      {
+        val x_41 = listValMut_4;
+        val x_42 = scala.collection.immutable.List.apply[meta.runtime.RequestMessage](x_41);
+        val x_43 = this.addReceiveMessages(x_42);
+        resetData_0 = x_43;
+        positionVar_8 = 5
+      }
+    else
+      ()
+  }));
+  data_9.update(11, (() => {
+    val x_44 = iterMut_5;
+    val x_45 = x_44.hasNext;
+    val x_46 = x_45.`unary_!`;
+    if (x_46)
+      positionVar_8 = 12
+    else
+      ()
+  }));
+  data_9.update(12, (() => positionVar_8 = 13));
+  data_9.update(13, (() => {
+    val x_47 = bindingMut_6;
+    val x_48 = x_47.<(1.0);
+    if (x_48)
+      positionVar_8 = 14
+    else
+      positionVar_8 = 17
+  }));
+  data_9.update(14, (() => {
+    val x_49 = bindingMut_6;
+    val x_50 = x_49.+(1);
+    resetData_0 = x_50;
+    val x_51 = resetData_0;
+    val x_52 = x_51.asInstanceOf[scala.Double];
+    bindingMut_6 = x_52;
+    positionVar_8 = 15;
+    unblockFlag_7 = false
+  }));
+  data_9.update(15, (() => positionVar_8 = 16));
+  data_9.update(16, (() => {
+    val x_53 = this.popRequestMessages;
+    val x_54 = x_53.iterator;
+    iterMut_5 = x_54;
+    positionVar_8 = 6
+  }));
+  data_9.update(17, (() => {
+    val x_55 = bindingMut_6;
+    val x_56 = x_55.<(1.0);
+    val x_57 = x_56.`unary_!`;
+    if (x_57)
+      positionVar_8 = 18
+    else
+      ()
+  }));
+  data_9.update(18, (() => positionVar_8 = 1));
+  data_9.update(19, (() => positionVar_8 = 20));
+  data_9.update(20, (() => {
+    positionVar_8 = 21;
+    unblockFlag_7 = false
+  }));
+  data_9.update(21, (() => positionVar_8 = 20));
+  data_9.update(22, (() => {
+    resetData_0 = 0.0;
+    val x_58 = resetData_0;
+    val x_59 = x_58.asInstanceOf[scala.Double];
+    bindingMut_6 = x_59;
+    positionVar_8 = 14
+  }));
+  data_9.update(23, (() => positionVar_8 = 20));
+  data_9
+}).apply();
+  
+
+  override def work(): Unit = 
+      scala.Predef.println("Work in a factory.")
+  
+  def wrapper_work(args: List[Any]): Unit = {
+    
+          
+          work()
+          
+  }
+  
+  override def run(msgs: List[meta.runtime.Message]): (List[meta.runtime.Message], Int) = {
+    addReceiveMessages(msgs)
+    sendMessages.clear()
+    unblockFlag_7 = true
+    while (unblockFlag_7 && (positionVar_8 < 24)) {
+      commands_60(positionVar_8)()
+    }
+    (sendMessages.toList, 1)
+  }
+
+  override def handleNonblockingMessage(m: meta.runtime.RequestMessage): Unit = {
+    val args = m.argss.flatten
+    val response = m.methodInfo match {
+      case Right(x) => {
+        x match {
+          case 0 => wrapper_work(args)
+        }
+      }
+      case Left(x) => println("For staged implementation only")
+    }
+    m.reply(this, response)
+  }
+  
+    override def gotoHandleMessages(new_ir: Int = 2): meta.runtime.Actor = {
+      // first entry, save the current IR to reflectionIR
+      unblockFlag_7 = true
+
+      if (reflectionIR_48 == -1){
+        reflectionIR_48 = positionVar_8
+        positionVar_8 = new_ir
+      }
+
+      while (positionVar_8 <= 17 && unblockFlag_7) {
+        commands_60(positionVar_8)()
+      }
+
+      // reset instruction register when finishes processing
+      if (positionVar_8 > 17) {
+        positionVar_8 = reflectionIR_48
+        reflectionIR_48 = -1
+      }
+      this
+    }
+    
+override def SimClone(): Worker = {
+  val newAgent = new Worker()
+
+  newAgent
+}
+
+override def SimReset(): Unit = {
+  positionVar_8 = 0
+  
+}
+
+}

--- a/core/src/test/scala/generated/inheritance2/InitData.scala
+++ b/core/src/test/scala/generated/inheritance2/InitData.scala
@@ -1,0 +1,21 @@
+package generated.meta.test.inheritance2
+
+object InitData  {
+    
+        def apply(): scala.`package`.List[meta.runtime.Actor] = {
+  val teacher = new Teacher();
+  val student = new Student(teacher);
+  scala.collection.immutable.List.apply[meta.test.Person](teacher, student)
+} 
+        
+        def wrapper(args: List[Any]): List[meta.runtime.Actor] = {
+          apply()
+        }
+        
+        def writeSchema(pw: java.io.PrintWriter): Unit = {
+          pw.write("")
+          pw.flush()
+        }
+        
+        
+}

--- a/core/src/test/scala/generated/inheritance2/Student.scala
+++ b/core/src/test/scala/generated/inheritance2/Student.scala
@@ -1,0 +1,254 @@
+package generated.meta.test.inheritance2
+
+class Student(var teacher: generated.meta.test.inheritance2.Teacher) extends meta.runtime.Actor with meta.test.Person {
+
+
+  private var  reflectionIR_80: Int = -1
+  var resetData_0: scala.Any = null
+  val resetData_1 = scala.collection.mutable.ListBuffer.apply[scala.collection.immutable.List[scala.Tuple2[scala.Tuple2[scala.Int, scala.Int], scala.Int]]]()
+  var resetData_2: meta.runtime.ResponseMessage = null
+  var bindingMut_3: scala.Any = null
+  var listValMut_4: meta.runtime.RequestMessage = null
+  @transient var iterMut_5: scala.collection.Iterator[meta.runtime.RequestMessage] = null
+  var bindingMut_6: scala.Double = 0.0
+  var unblockFlag_7: scala.Boolean = true
+  var positionVar_8: scala.Int = 0
+  
+  val commands_76 = (() => {
+  val data_9 = new scala.Array[scala.Function0[scala.Unit]](24);
+  data_9.update(0, (() => positionVar_8 = 1));
+  data_9.update(1, (() => {
+    positionVar_8 = 2;
+    val x_10 = scala.Tuple2.apply[scala.Int, scala.Int](-1, -1);
+    val x_11 = scala.Tuple2.apply[scala.Tuple2[scala.Int, scala.Int], scala.Int](x_10, 22);
+    val x_12 = scala.collection.immutable.Nil.::[scala.Tuple2[scala.Tuple2[scala.Int, scala.Int], scala.Int]](x_11);
+    resetData_1.prepend(x_12)
+  }));
+  data_9.update(2, (() => {
+    scala.Predef.println("Study at school");
+    resetData_0 = ();
+    val x_13 = resetData_1.remove(0);
+    val x_17 = x_13.find(((x_14: scala.Tuple2[scala.Tuple2[scala.Int, scala.Int], scala.Int]) => {
+      val x_15 = x_14._1;
+      val x_16 = scala.Tuple2.apply[scala.Int, scala.Int](-1, -1);
+      x_15.==(x_16)
+    }));
+    val x_18 = x_17.get;
+    val x_19 = x_18._2;
+    positionVar_8 = x_19
+  }));
+  data_9.update(3, (() => {
+    val x_20 = resetData_0;
+    val x_21 = x_20.asInstanceOf[scala.Any];
+    bindingMut_3 = x_21;
+    val x_22 = bindingMut_3;
+    val x_23 = listValMut_4;
+    x_23.reply(this, x_22);
+    resetData_0 = ();
+    positionVar_8 = 4
+  }));
+  data_9.update(4, (() => positionVar_8 = 5));
+  data_9.update(5, (() => positionVar_8 = 6));
+  data_9.update(6, (() => {
+    val x_24 = iterMut_5;
+    val x_25 = x_24.hasNext;
+    if (x_25)
+      {
+        val x_26 = iterMut_5;
+        val x_27 = x_26.next();
+        listValMut_4 = x_27;
+        positionVar_8 = 7
+      }
+    else
+      positionVar_8 = 11
+  }));
+  data_9.update(7, (() => {
+    val x_28 = listValMut_4;
+    val x_29 = x_28.methodInfo;
+    val x_30 = scala.`package`.Right.apply[scala.Nothing, scala.Int](3);
+    val x_31 = x_29.==(x_30);
+    if (x_31)
+      positionVar_8 = 8
+    else
+      positionVar_8 = 10
+  }));
+  data_9.update(8, (() => {
+    val x_32 = listValMut_4;
+    this.handleNonblockingMessage(x_32);
+    resetData_0 = ();
+    positionVar_8 = 4
+  }));
+  data_9.update(9, (() => {
+    positionVar_8 = 2;
+    val x_33 = scala.Tuple2.apply[scala.Int, scala.Int](-1, -1);
+    val x_34 = scala.Tuple2.apply[scala.Tuple2[scala.Int, scala.Int], scala.Int](x_33, 3);
+    val x_35 = scala.collection.immutable.Nil.::[scala.Tuple2[scala.Tuple2[scala.Int, scala.Int], scala.Int]](x_34);
+    resetData_1.prepend(x_35)
+  }));
+  data_9.update(10, (() => {
+    val x_36 = listValMut_4;
+    val x_37 = x_36.methodInfo;
+    val x_38 = scala.`package`.Right.apply[scala.Nothing, scala.Int](3);
+    val x_39 = x_37.==(x_38);
+    val x_40 = x_39.`unary_!`;
+    if (x_40)
+      {
+        val x_41 = listValMut_4;
+        val x_42 = scala.collection.immutable.List.apply[meta.runtime.RequestMessage](x_41);
+        val x_43 = this.addReceiveMessages(x_42);
+        resetData_0 = x_43;
+        positionVar_8 = 5
+      }
+    else
+      ()
+  }));
+  data_9.update(11, (() => {
+    val x_44 = iterMut_5;
+    val x_45 = x_44.hasNext;
+    val x_46 = x_45.`unary_!`;
+    if (x_46)
+      positionVar_8 = 12
+    else
+      ()
+  }));
+  data_9.update(12, (() => positionVar_8 = 13));
+  data_9.update(13, (() => {
+    val x_47 = bindingMut_6;
+    val x_48 = x_47.<(1.0);
+    if (x_48)
+      positionVar_8 = 14
+    else
+      positionVar_8 = 17
+  }));
+  data_9.update(14, (() => {
+    val x_49 = bindingMut_6;
+    val x_50 = x_49.+(1);
+    resetData_0 = x_50;
+    val x_51 = resetData_0;
+    val x_52 = x_51.asInstanceOf[scala.Double];
+    bindingMut_6 = x_52;
+    positionVar_8 = 15;
+    unblockFlag_7 = false
+  }));
+  data_9.update(15, (() => positionVar_8 = 16));
+  data_9.update(16, (() => {
+    val x_53 = this.popRequestMessages;
+    val x_54 = x_53.iterator;
+    iterMut_5 = x_54;
+    positionVar_8 = 6
+  }));
+  data_9.update(17, (() => {
+    val x_55 = bindingMut_6;
+    val x_56 = x_55.<(1.0);
+    val x_57 = x_56.`unary_!`;
+    if (x_57)
+      positionVar_8 = 18
+    else
+      ()
+  }));
+  data_9.update(18, (() => positionVar_8 = 1));
+  data_9.update(19, (() => positionVar_8 = 20));
+  data_9.update(20, (() => {
+    positionVar_8 = 21;
+    unblockFlag_7 = false
+  }));
+  data_9.update(21, (() => positionVar_8 = 20));
+  data_9.update(22, (() => {
+    val receiver_58 = this.teacher;
+    val x_59 = ((this): meta.runtime.Actor).id;
+    val x_60 = receiver_58.id;
+    val x_61 = scala.`package`.Right.apply[scala.Nothing, scala.Int](0);
+    val x_62 = scala.collection.immutable.Nil.::[scala.collection.immutable.List[scala.Any]](((scala.collection.immutable.Nil): scala.collection.immutable.List[scala.Any]));
+    val x_63 = meta.runtime.RequestMessage.apply(x_59, x_60, false, x_61, x_62);
+    val x_64 = x_63.sessionId;
+    val x_65 = meta.runtime.Future.apply$default$2[scala.Unit];
+    val x_66 = meta.runtime.Future.apply[scala.Unit](x_64, x_65);
+    var v_67: meta.runtime.Future[scala.Unit] = x_66;
+    ((this): meta.runtime.Actor).sendMessage(x_63);
+    val x_68 = x_63.sessionId;
+    ((this): meta.runtime.Actor).setMessageResponseHandler(x_68, ((response_69: meta.runtime.Message) => {
+      val x_70 = v_67;
+      val x_71 = response_69.asInstanceOf[meta.runtime.ResponseMessage];
+      val x_72 = x_71.arg;
+      x_72.asInstanceOf[scala.Unit];
+      x_70.setValue(())
+    }));
+    val x_73 = v_67;
+    resetData_0 = x_73;
+    resetData_0 = 0.0;
+    val x_74 = resetData_0;
+    val x_75 = x_74.asInstanceOf[scala.Double];
+    bindingMut_6 = x_75;
+    positionVar_8 = 14
+  }));
+  data_9.update(23, (() => positionVar_8 = 20));
+  data_9
+}).apply();
+  
+
+  override def work(): Unit = 
+      scala.Predef.println("Study at school")
+  
+  def wrapper_work(args: List[Any]): Unit = {
+    
+          
+          work()
+          
+  }
+  
+  override def run(msgs: List[meta.runtime.Message]): (List[meta.runtime.Message], Int) = {
+    addReceiveMessages(msgs)
+    sendMessages.clear()
+    unblockFlag_7 = true
+    while (unblockFlag_7 && (positionVar_8 < 24)) {
+      commands_76(positionVar_8)()
+    }
+    (sendMessages.toList, 1)
+  }
+
+  override def handleNonblockingMessage(m: meta.runtime.RequestMessage): Unit = {
+    val args = m.argss.flatten
+    val response = m.methodInfo match {
+      case Right(x) => {
+        x match {
+          case 3 => wrapper_work(args)
+        }
+      }
+      case Left(x) => println("For staged implementation only")
+    }
+    m.reply(this, response)
+  }
+  
+    override def gotoHandleMessages(new_ir: Int = 2): meta.runtime.Actor = {
+      // first entry, save the current IR to reflectionIR
+      unblockFlag_7 = true
+
+      if (reflectionIR_80 == -1){
+        reflectionIR_80 = positionVar_8
+        positionVar_8 = new_ir
+      }
+
+      while (positionVar_8 <= 17 && unblockFlag_7) {
+        commands_76(positionVar_8)()
+      }
+
+      // reset instruction register when finishes processing
+      if (positionVar_8 > 17) {
+        positionVar_8 = reflectionIR_80
+        reflectionIR_80 = -1
+      }
+      this
+    }
+    
+override def SimClone(): Student = {
+  val newAgent = new Student(teacher)
+
+  newAgent
+}
+
+override def SimReset(): Unit = {
+  positionVar_8 = 0
+  
+}
+
+}

--- a/core/src/test/scala/generated/inheritance2/Student.scala
+++ b/core/src/test/scala/generated/inheritance2/Student.scala
@@ -1,9 +1,9 @@
 package generated.meta.test.inheritance2
 
-class Student(var teacher: generated.meta.test.inheritance2.Teacher) extends meta.runtime.Actor with meta.test.Person {
+class Student(var neighbor: generated.meta.test.inheritance2.Teacher) extends meta.runtime.Actor with meta.test.Person {
 
 
-  private var  reflectionIR_80: Int = -1
+  private var  reflectionIR_73: Int = -1
   var resetData_0: scala.Any = null
   val resetData_1 = scala.collection.mutable.ListBuffer.apply[scala.collection.immutable.List[scala.Tuple2[scala.Tuple2[scala.Int, scala.Int], scala.Int]]]()
   var resetData_2: meta.runtime.ResponseMessage = null
@@ -65,7 +65,7 @@ class Student(var teacher: generated.meta.test.inheritance2.Teacher) extends met
   data_9.update(7, (() => {
     val x_28 = listValMut_4;
     val x_29 = x_28.methodInfo;
-    val x_30 = scala.`package`.Right.apply[scala.Nothing, scala.Int](3);
+    val x_30 = scala.`package`.Right.apply[scala.Nothing, scala.Int](4);
     val x_31 = x_29.==(x_30);
     if (x_31)
       positionVar_8 = 8
@@ -88,7 +88,7 @@ class Student(var teacher: generated.meta.test.inheritance2.Teacher) extends met
   data_9.update(10, (() => {
     val x_36 = listValMut_4;
     val x_37 = x_36.methodInfo;
-    val x_38 = scala.`package`.Right.apply[scala.Nothing, scala.Int](3);
+    val x_38 = scala.`package`.Right.apply[scala.Nothing, scala.Int](4);
     val x_39 = x_37.==(x_38);
     val x_40 = x_39.`unary_!`;
     if (x_40)
@@ -154,7 +154,7 @@ class Student(var teacher: generated.meta.test.inheritance2.Teacher) extends met
   }));
   data_9.update(21, (() => positionVar_8 = 20));
   data_9.update(22, (() => {
-    val receiver_58 = this.teacher;
+    val receiver_58 = this.neighbor;
     val x_59 = ((this): meta.runtime.Actor).id;
     val x_60 = receiver_58.id;
     val x_61 = scala.`package`.Right.apply[scala.Nothing, scala.Int](0);
@@ -211,7 +211,7 @@ class Student(var teacher: generated.meta.test.inheritance2.Teacher) extends met
     val response = m.methodInfo match {
       case Right(x) => {
         x match {
-          case 3 => wrapper_work(args)
+          case 4 => wrapper_work(args)
         }
       }
       case Left(x) => println("For staged implementation only")
@@ -223,8 +223,8 @@ class Student(var teacher: generated.meta.test.inheritance2.Teacher) extends met
       // first entry, save the current IR to reflectionIR
       unblockFlag_7 = true
 
-      if (reflectionIR_80 == -1){
-        reflectionIR_80 = positionVar_8
+      if (reflectionIR_73 == -1){
+        reflectionIR_73 = positionVar_8
         positionVar_8 = new_ir
       }
 
@@ -234,14 +234,14 @@ class Student(var teacher: generated.meta.test.inheritance2.Teacher) extends met
 
       // reset instruction register when finishes processing
       if (positionVar_8 > 17) {
-        positionVar_8 = reflectionIR_80
-        reflectionIR_80 = -1
+        positionVar_8 = reflectionIR_73
+        reflectionIR_73 = -1
       }
       this
     }
     
 override def SimClone(): Student = {
-  val newAgent = new Student(teacher)
+  val newAgent = new Student(neighbor)
 
   newAgent
 }

--- a/core/src/test/scala/generated/inheritance2/Teacher.scala
+++ b/core/src/test/scala/generated/inheritance2/Teacher.scala
@@ -3,7 +3,7 @@ package generated.meta.test.inheritance2
 class Teacher() extends meta.runtime.Actor with meta.test.Person {
 
 
-  private var  reflectionIR_26: Int = -1
+  private var  reflectionIR_87: Int = -1
   var resetData_0: scala.Any = null
   val resetData_1 = scala.collection.mutable.ListBuffer.apply[scala.collection.immutable.List[scala.Tuple2[scala.Tuple2[scala.Int, scala.Int], scala.Int]]]()
   var resetData_2: meta.runtime.ResponseMessage = null
@@ -15,13 +15,13 @@ class Teacher() extends meta.runtime.Actor with meta.test.Person {
   var unblockFlag_8: scala.Boolean = true
   var positionVar_9: scala.Int = 0
   
-  val commands_71 = (() => {
-  val data_10 = new scala.Array[scala.Function0[scala.Unit]](27);
+  val commands_87 = (() => {
+  val data_10 = new scala.Array[scala.Function0[scala.Unit]](33);
   data_10.update(0, (() => positionVar_9 = 1));
   data_10.update(1, (() => {
     positionVar_9 = 2;
     val x_11 = scala.Tuple2.apply[scala.Int, scala.Int](-1, -1);
-    val x_12 = scala.Tuple2.apply[scala.Tuple2[scala.Int, scala.Int], scala.Int](x_11, 25);
+    val x_12 = scala.Tuple2.apply[scala.Tuple2[scala.Int, scala.Int], scala.Int](x_11, 31);
     val x_13 = scala.collection.immutable.Nil.::[scala.Tuple2[scala.Tuple2[scala.Int, scala.Int], scala.Int]](x_12);
     resetData_1.prepend(x_13)
   }));
@@ -94,7 +94,7 @@ class Teacher() extends meta.runtime.Actor with meta.test.Person {
         positionVar_9 = 10
       }
     else
-      positionVar_9 = 14
+      positionVar_9 = 19
   }));
   data_10.update(10, (() => {
     val x_40 = listValMut_5;
@@ -104,92 +104,132 @@ class Teacher() extends meta.runtime.Actor with meta.test.Person {
     if (x_43)
       positionVar_9 = 11
     else
-      positionVar_9 = 13
+      positionVar_9 = 14
   }));
-  data_10.update(11, (() => positionVar_9 = 12));
-  data_10.update(12, (() => {
+  data_10.update(11, (() => positionVar_9 = 13));
+  data_10.update(12, (() => positionVar_9 = 8));
+  data_10.update(13, (() => {
     positionVar_9 = 2;
     val x_44 = scala.Tuple2.apply[scala.Int, scala.Int](-1, -1);
-    val x_45 = scala.Tuple2.apply[scala.Tuple2[scala.Int, scala.Int], scala.Int](x_44, 6);
+    val x_45 = scala.Tuple2.apply[scala.Tuple2[scala.Int, scala.Int], scala.Int](x_44, 30);
     val x_46 = scala.collection.immutable.Nil.::[scala.Tuple2[scala.Tuple2[scala.Int, scala.Int], scala.Int]](x_45);
     resetData_1.prepend(x_46)
   }));
-  data_10.update(13, (() => {
+  data_10.update(14, (() => {
     val x_47 = listValMut_5;
     val x_48 = x_47.methodInfo;
     val x_49 = scala.`package`.Right.apply[scala.Nothing, scala.Int](0);
     val x_50 = x_48.==(x_49);
     val x_51 = x_50.`unary_!`;
     if (x_51)
+      positionVar_9 = 15
+    else
+      ()
+  }));
+  data_10.update(15, (() => {
+    val x_52 = listValMut_5;
+    val x_53 = x_52.methodInfo;
+    val x_54 = scala.`package`.Right.apply[scala.Nothing, scala.Int](0);
+    val x_55 = x_53.==(x_54);
+    if (x_55)
+      positionVar_9 = 16
+    else
+      positionVar_9 = 18
+  }));
+  data_10.update(16, (() => positionVar_9 = 17));
+  data_10.update(17, (() => {
+    positionVar_9 = 2;
+    val x_56 = scala.Tuple2.apply[scala.Int, scala.Int](-1, -1);
+    val x_57 = scala.Tuple2.apply[scala.Tuple2[scala.Int, scala.Int], scala.Int](x_56, 6);
+    val x_58 = scala.collection.immutable.Nil.::[scala.Tuple2[scala.Tuple2[scala.Int, scala.Int], scala.Int]](x_57);
+    resetData_1.prepend(x_58)
+  }));
+  data_10.update(18, (() => {
+    val x_59 = listValMut_5;
+    val x_60 = x_59.methodInfo;
+    val x_61 = scala.`package`.Right.apply[scala.Nothing, scala.Int](0);
+    val x_62 = x_60.==(x_61);
+    val x_63 = x_62.`unary_!`;
+    if (x_63)
       {
-        val x_52 = listValMut_5;
-        val x_53 = scala.collection.immutable.List.apply[meta.runtime.RequestMessage](x_52);
-        val x_54 = this.addReceiveMessages(x_53);
-        resetData_0 = x_54;
+        val x_64 = listValMut_5;
+        val x_65 = scala.collection.immutable.List.apply[meta.runtime.RequestMessage](x_64);
+        val x_66 = this.addReceiveMessages(x_65);
+        resetData_0 = x_66;
         positionVar_9 = 8
       }
     else
       ()
   }));
-  data_10.update(14, (() => {
-    val x_55 = iterMut_6;
-    val x_56 = x_55.hasNext;
-    val x_57 = x_56.`unary_!`;
-    if (x_57)
-      positionVar_9 = 15
+  data_10.update(19, (() => {
+    val x_67 = iterMut_6;
+    val x_68 = x_67.hasNext;
+    val x_69 = x_68.`unary_!`;
+    if (x_69)
+      positionVar_9 = 20
     else
       ()
   }));
-  data_10.update(15, (() => positionVar_9 = 16));
-  data_10.update(16, (() => {
-    val x_58 = bindingMut_7;
-    val x_59 = x_58.<(1.0);
-    if (x_59)
-      positionVar_9 = 17
+  data_10.update(20, (() => positionVar_9 = 21));
+  data_10.update(21, (() => {
+    val x_70 = bindingMut_7;
+    val x_71 = x_70.<(1.0);
+    if (x_71)
+      positionVar_9 = 22
     else
-      positionVar_9 = 20
+      positionVar_9 = 25
   }));
-  data_10.update(17, (() => {
-    val x_60 = bindingMut_7;
-    val x_61 = x_60.+(1);
-    resetData_0 = x_61;
-    val x_62 = resetData_0;
-    val x_63 = x_62.asInstanceOf[scala.Double];
-    bindingMut_7 = x_63;
-    positionVar_9 = 18;
+  data_10.update(22, (() => {
+    val x_72 = bindingMut_7;
+    val x_73 = x_72.+(1);
+    resetData_0 = x_73;
+    val x_74 = resetData_0;
+    val x_75 = x_74.asInstanceOf[scala.Double];
+    bindingMut_7 = x_75;
+    positionVar_9 = 23;
     unblockFlag_8 = false
   }));
-  data_10.update(18, (() => positionVar_9 = 19));
-  data_10.update(19, (() => {
-    val x_64 = this.popRequestMessages;
-    val x_65 = x_64.iterator;
-    iterMut_6 = x_65;
+  data_10.update(23, (() => positionVar_9 = 24));
+  data_10.update(24, (() => {
+    val x_76 = this.popRequestMessages;
+    val x_77 = x_76.iterator;
+    iterMut_6 = x_77;
     positionVar_9 = 9
   }));
-  data_10.update(20, (() => {
-    val x_66 = bindingMut_7;
-    val x_67 = x_66.<(1.0);
-    val x_68 = x_67.`unary_!`;
-    if (x_68)
-      positionVar_9 = 21
+  data_10.update(25, (() => {
+    val x_78 = bindingMut_7;
+    val x_79 = x_78.<(1.0);
+    val x_80 = x_79.`unary_!`;
+    if (x_80)
+      positionVar_9 = 26
     else
       ()
   }));
-  data_10.update(21, (() => positionVar_9 = 1));
-  data_10.update(22, (() => positionVar_9 = 23));
-  data_10.update(23, (() => {
-    positionVar_9 = 24;
+  data_10.update(26, (() => positionVar_9 = 1));
+  data_10.update(27, (() => positionVar_9 = 28));
+  data_10.update(28, (() => {
+    positionVar_9 = 29;
     unblockFlag_8 = false
   }));
-  data_10.update(24, (() => positionVar_9 = 23));
-  data_10.update(25, (() => {
-    resetData_0 = 0.0;
-    val x_69 = resetData_0;
-    val x_70 = x_69.asInstanceOf[scala.Double];
-    bindingMut_7 = x_70;
-    positionVar_9 = 17
+  data_10.update(29, (() => positionVar_9 = 28));
+  data_10.update(30, (() => {
+    val x_81 = resetData_0;
+    val x_82 = x_81.asInstanceOf[scala.Any];
+    bindingMut_4 = x_82;
+    val x_83 = bindingMut_4;
+    val x_84 = listValMut_5;
+    x_84.reply(this, x_83);
+    resetData_0 = ();
+    positionVar_9 = 12
   }));
-  data_10.update(26, (() => positionVar_9 = 23));
+  data_10.update(31, (() => {
+    resetData_0 = 0.0;
+    val x_85 = resetData_0;
+    val x_86 = x_85.asInstanceOf[scala.Double];
+    bindingMut_7 = x_86;
+    positionVar_9 = 22
+  }));
+  data_10.update(32, (() => positionVar_9 = 28));
   data_10
 }).apply();
   
@@ -198,8 +238,8 @@ class Teacher() extends meta.runtime.Actor with meta.test.Person {
     addReceiveMessages(msgs)
     sendMessages.clear()
     unblockFlag_8 = true
-    while (unblockFlag_8 && (positionVar_9 < 27)) {
-      commands_71(positionVar_9)()
+    while (unblockFlag_8 && (positionVar_9 < 33)) {
+      commands_87(positionVar_9)()
     }
     (sendMessages.toList, 1)
   }
@@ -208,19 +248,19 @@ class Teacher() extends meta.runtime.Actor with meta.test.Person {
       // first entry, save the current IR to reflectionIR
       unblockFlag_8 = true
 
-      if (reflectionIR_26 == -1){
-        reflectionIR_26 = positionVar_9
+      if (reflectionIR_87 == -1){
+        reflectionIR_87 = positionVar_9
         positionVar_9 = new_ir
       }
 
-      while (positionVar_9 <= 20 && unblockFlag_8) {
-        commands_71(positionVar_9)()
+      while (positionVar_9 <= 25 && unblockFlag_8) {
+        commands_87(positionVar_9)()
       }
 
       // reset instruction register when finishes processing
-      if (positionVar_9 > 20) {
-        positionVar_9 = reflectionIR_26
-        reflectionIR_26 = -1
+      if (positionVar_9 > 25) {
+        positionVar_9 = reflectionIR_87
+        reflectionIR_87 = -1
       }
       this
     }

--- a/core/src/test/scala/generated/inheritance2/Teacher.scala
+++ b/core/src/test/scala/generated/inheritance2/Teacher.scala
@@ -1,0 +1,239 @@
+package generated.meta.test.inheritance2
+
+class Teacher() extends meta.runtime.Actor with meta.test.Person {
+
+
+  private var  reflectionIR_26: Int = -1
+  var resetData_0: scala.Any = null
+  val resetData_1 = scala.collection.mutable.ListBuffer.apply[scala.collection.immutable.List[scala.Tuple2[scala.Tuple2[scala.Int, scala.Int], scala.Int]]]()
+  var resetData_2: meta.runtime.ResponseMessage = null
+  var bindingMut_3: scala.Double = 0.0
+  var bindingMut_4: scala.Any = null
+  var listValMut_5: meta.runtime.RequestMessage = null
+  @transient var iterMut_6: scala.collection.Iterator[meta.runtime.RequestMessage] = null
+  var bindingMut_7: scala.Double = 0.0
+  var unblockFlag_8: scala.Boolean = true
+  var positionVar_9: scala.Int = 0
+  
+  val commands_71 = (() => {
+  val data_10 = new scala.Array[scala.Function0[scala.Unit]](27);
+  data_10.update(0, (() => positionVar_9 = 1));
+  data_10.update(1, (() => {
+    positionVar_9 = 2;
+    val x_11 = scala.Tuple2.apply[scala.Int, scala.Int](-1, -1);
+    val x_12 = scala.Tuple2.apply[scala.Tuple2[scala.Int, scala.Int], scala.Int](x_11, 25);
+    val x_13 = scala.collection.immutable.Nil.::[scala.Tuple2[scala.Tuple2[scala.Int, scala.Int], scala.Int]](x_12);
+    resetData_1.prepend(x_13)
+  }));
+  data_10.update(2, (() => {
+    scala.Predef.println("Teach in a classroom. ");
+    resetData_0 = ();
+    resetData_0 = 0.0;
+    val x_14 = resetData_0;
+    val x_15 = x_14.asInstanceOf[scala.Double];
+    bindingMut_3 = x_15;
+    positionVar_9 = 3
+  }));
+  data_10.update(3, (() => {
+    val x_16 = bindingMut_3;
+    val x_17 = x_16.+(1);
+    resetData_0 = x_17;
+    val x_18 = resetData_0;
+    val x_19 = x_18.asInstanceOf[scala.Double];
+    bindingMut_3 = x_19;
+    positionVar_9 = 4;
+    unblockFlag_8 = false
+  }));
+  data_10.update(4, (() => {
+    val x_20 = bindingMut_3;
+    val x_21 = x_20.<(1.0);
+    if (x_21)
+      positionVar_9 = 3
+    else
+      positionVar_9 = 5
+  }));
+  data_10.update(5, (() => {
+    val x_22 = bindingMut_3;
+    val x_23 = x_22.<(1.0);
+    val x_24 = x_23.`unary_!`;
+    if (x_24)
+      {
+        val x_25 = resetData_1.remove(0);
+        val x_29 = x_25.find(((x_26: scala.Tuple2[scala.Tuple2[scala.Int, scala.Int], scala.Int]) => {
+          val x_27 = x_26._1;
+          val x_28 = scala.Tuple2.apply[scala.Int, scala.Int](-1, -1);
+          x_27.==(x_28)
+        }));
+        val x_30 = x_29.get;
+        val x_31 = x_30._2;
+        positionVar_9 = x_31
+      }
+    else
+      ()
+  }));
+  data_10.update(6, (() => {
+    val x_32 = resetData_0;
+    val x_33 = x_32.asInstanceOf[scala.Any];
+    bindingMut_4 = x_33;
+    val x_34 = bindingMut_4;
+    val x_35 = listValMut_5;
+    x_35.reply(this, x_34);
+    resetData_0 = ();
+    positionVar_9 = 7
+  }));
+  data_10.update(7, (() => positionVar_9 = 8));
+  data_10.update(8, (() => positionVar_9 = 9));
+  data_10.update(9, (() => {
+    val x_36 = iterMut_6;
+    val x_37 = x_36.hasNext;
+    if (x_37)
+      {
+        val x_38 = iterMut_6;
+        val x_39 = x_38.next();
+        listValMut_5 = x_39;
+        positionVar_9 = 10
+      }
+    else
+      positionVar_9 = 14
+  }));
+  data_10.update(10, (() => {
+    val x_40 = listValMut_5;
+    val x_41 = x_40.methodInfo;
+    val x_42 = scala.`package`.Right.apply[scala.Nothing, scala.Int](0);
+    val x_43 = x_41.==(x_42);
+    if (x_43)
+      positionVar_9 = 11
+    else
+      positionVar_9 = 13
+  }));
+  data_10.update(11, (() => positionVar_9 = 12));
+  data_10.update(12, (() => {
+    positionVar_9 = 2;
+    val x_44 = scala.Tuple2.apply[scala.Int, scala.Int](-1, -1);
+    val x_45 = scala.Tuple2.apply[scala.Tuple2[scala.Int, scala.Int], scala.Int](x_44, 6);
+    val x_46 = scala.collection.immutable.Nil.::[scala.Tuple2[scala.Tuple2[scala.Int, scala.Int], scala.Int]](x_45);
+    resetData_1.prepend(x_46)
+  }));
+  data_10.update(13, (() => {
+    val x_47 = listValMut_5;
+    val x_48 = x_47.methodInfo;
+    val x_49 = scala.`package`.Right.apply[scala.Nothing, scala.Int](0);
+    val x_50 = x_48.==(x_49);
+    val x_51 = x_50.`unary_!`;
+    if (x_51)
+      {
+        val x_52 = listValMut_5;
+        val x_53 = scala.collection.immutable.List.apply[meta.runtime.RequestMessage](x_52);
+        val x_54 = this.addReceiveMessages(x_53);
+        resetData_0 = x_54;
+        positionVar_9 = 8
+      }
+    else
+      ()
+  }));
+  data_10.update(14, (() => {
+    val x_55 = iterMut_6;
+    val x_56 = x_55.hasNext;
+    val x_57 = x_56.`unary_!`;
+    if (x_57)
+      positionVar_9 = 15
+    else
+      ()
+  }));
+  data_10.update(15, (() => positionVar_9 = 16));
+  data_10.update(16, (() => {
+    val x_58 = bindingMut_7;
+    val x_59 = x_58.<(1.0);
+    if (x_59)
+      positionVar_9 = 17
+    else
+      positionVar_9 = 20
+  }));
+  data_10.update(17, (() => {
+    val x_60 = bindingMut_7;
+    val x_61 = x_60.+(1);
+    resetData_0 = x_61;
+    val x_62 = resetData_0;
+    val x_63 = x_62.asInstanceOf[scala.Double];
+    bindingMut_7 = x_63;
+    positionVar_9 = 18;
+    unblockFlag_8 = false
+  }));
+  data_10.update(18, (() => positionVar_9 = 19));
+  data_10.update(19, (() => {
+    val x_64 = this.popRequestMessages;
+    val x_65 = x_64.iterator;
+    iterMut_6 = x_65;
+    positionVar_9 = 9
+  }));
+  data_10.update(20, (() => {
+    val x_66 = bindingMut_7;
+    val x_67 = x_66.<(1.0);
+    val x_68 = x_67.`unary_!`;
+    if (x_68)
+      positionVar_9 = 21
+    else
+      ()
+  }));
+  data_10.update(21, (() => positionVar_9 = 1));
+  data_10.update(22, (() => positionVar_9 = 23));
+  data_10.update(23, (() => {
+    positionVar_9 = 24;
+    unblockFlag_8 = false
+  }));
+  data_10.update(24, (() => positionVar_9 = 23));
+  data_10.update(25, (() => {
+    resetData_0 = 0.0;
+    val x_69 = resetData_0;
+    val x_70 = x_69.asInstanceOf[scala.Double];
+    bindingMut_7 = x_70;
+    positionVar_9 = 17
+  }));
+  data_10.update(26, (() => positionVar_9 = 23));
+  data_10
+}).apply();
+  
+
+  override def run(msgs: List[meta.runtime.Message]): (List[meta.runtime.Message], Int) = {
+    addReceiveMessages(msgs)
+    sendMessages.clear()
+    unblockFlag_8 = true
+    while (unblockFlag_8 && (positionVar_9 < 27)) {
+      commands_71(positionVar_9)()
+    }
+    (sendMessages.toList, 1)
+  }
+
+    override def gotoHandleMessages(new_ir: Int = 5): meta.runtime.Actor = {
+      // first entry, save the current IR to reflectionIR
+      unblockFlag_8 = true
+
+      if (reflectionIR_26 == -1){
+        reflectionIR_26 = positionVar_9
+        positionVar_9 = new_ir
+      }
+
+      while (positionVar_9 <= 20 && unblockFlag_8) {
+        commands_71(positionVar_9)()
+      }
+
+      // reset instruction register when finishes processing
+      if (positionVar_9 > 20) {
+        positionVar_9 = reflectionIR_26
+        reflectionIR_26 = -1
+      }
+      this
+    }
+    
+override def SimClone(): Teacher = {
+  val newAgent = new Teacher()
+
+  newAgent
+}
+
+override def SimReset(): Unit = {
+  positionVar_9 = 0
+  
+}
+
+}

--- a/core/src/test/scala/lifterTest1.scala
+++ b/core/src/test/scala/lifterTest1.scala
@@ -32,7 +32,7 @@ class AgentWithBlockingCall(val n: AgentWithBlockingCall) extends Actor {
 }
 
 
-class lifterMethodTest extends FlatSpec with org.scalatest.Matchers {
+class lifterTest1 extends FlatSpec with org.scalatest.Matchers {
     import meta.deep.IR.Predef._
     import meta.classLifting.Lifter
 

--- a/core/src/test/scala/lifterTest2.scala
+++ b/core/src/test/scala/lifterTest2.scala
@@ -49,7 +49,7 @@ class MyClass5(var s: MyClass4) extends Actor {
     }
 }
 
-class lifterMethodTest2 extends FlatSpec with org.scalatest.Matchers {
+class lifterTest2 extends FlatSpec with org.scalatest.Matchers {
     import meta.deep.IR.Predef._
     import meta.classLifting.Lifter
 

--- a/core/src/test/scala/lifterTest3.scala
+++ b/core/src/test/scala/lifterTest3.scala
@@ -50,27 +50,27 @@ class lifterTest3 extends FlatSpec {
     import meta.deep.IR.Predef._
     import meta.classLifting.Lifter
 
-    "Lifting agents with overriding keywords" should "compile" in {
-        val workerClass: ClassWithObject[Worker] = Worker.reflect(IR)
-        val teacherClass: ClassWithObject[Teacher] = Teacher.reflect(IR)
+    // "Lifting agents with overriding keywords" should "compile" in {
+    //     val workerClass: ClassWithObject[Worker] = Worker.reflect(IR)
+    //     val teacherClass: ClassWithObject[Teacher] = Teacher.reflect(IR)
 
-        val liftedMain = meta.classLifting.liteLift {
-            def apply(): List[Actor] = {
-                val teacher = new Teacher()
-                val worker = new Worker()
-                List(teacher, worker)
-            }
-        }
+    //     val liftedMain = meta.classLifting.liteLift {
+    //         def apply(): List[Actor] = {
+    //             val teacher = new Teacher()
+    //             val worker = new Worker()
+    //             List(teacher, worker)
+    //         }
+    //     }
 
-        compileSims(List(workerClass, teacherClass), 
-            mainInit = Some(liftedMain), 
-            initPkgName = Some(this.getClass().getPackage().getName()+".inheritance"),
-            destFolder = "core/src/test/scala/generated/inheritance/")
-    }
-
-    // "Calling overriden methods" should "invoke local methods" in {
-    //     val agents = generated.meta.test.inheritance.InitData()
-    //     val c = new SimulationConfig(agents, 5)
-    //     val r = StartSimulation[BaseMessagingLayer.type](c)
+    //     compileSims(List(workerClass, teacherClass), 
+    //         mainInit = Some(liftedMain), 
+    //         initPkgName = Some(this.getClass().getPackage().getName()+".inheritance"),
+    //         destFolder = "core/src/test/scala/generated/inheritance/")
     // }
+
+    "Calling overriden methods" should "invoke local methods" in {
+        val agents = generated.meta.test.inheritance.InitData()
+        val c = new SimulationConfig(agents, 5)
+        val r = StartSimulation[BaseMessagingLayer.type](c)
+    }
 }

--- a/core/src/test/scala/lifterTest3.scala
+++ b/core/src/test/scala/lifterTest3.scala
@@ -23,6 +23,10 @@ class Worker() extends Person {
         println("Work in a factory.")
     }
 
+    override def work(): Unit = {
+        override_work()
+    }
+
     def main(): Unit = {
         while (true) {
             work()
@@ -36,6 +40,10 @@ class Teacher() extends Person {
     def override_work(): Unit = {
         println("Teach in a classroom. ")
         waitLabel(Turn, 1)
+    }
+
+    override def work(): Unit = {
+        override_work()
     }
 
     def main(): Unit = {

--- a/core/src/test/scala/lifterTest3.scala
+++ b/core/src/test/scala/lifterTest3.scala
@@ -18,7 +18,8 @@ trait Person extends Actor {
 
 @lift
 class Worker() extends Person {
-    // Equivalent to override def work() ...
+    // If both override_work and @override work are defined, then
+    // the compiler uses the definition in override_ as final
     def override_work(): Unit = {
         println("Work in a factory.")
     }

--- a/core/src/test/scala/lifterTest3.scala
+++ b/core/src/test/scala/lifterTest3.scala
@@ -1,0 +1,76 @@
+package meta.test
+
+import meta.classLifting.SpecialInstructions._
+import squid.quasi.lift
+import meta.deep.IR.TopLevel.ClassWithObject
+import meta.deep.IR
+import meta.runtime.{Actor}
+import meta.API._
+import org.scalatest.FlatSpec
+import java.io.File
+
+/**
+ * Test override
+ */
+trait Person extends Actor {
+    def work(): Unit = println("This is the parent class!")
+}
+
+@lift
+class Worker() extends Person {
+    // Equivalent to override def work() ...
+    def override_work(): Unit = {
+        println("Work in a factory.")
+    }
+
+    def main(): Unit = {
+        while (true) {
+            work()
+            waitAndReply(1)
+        }
+    }
+}
+
+@lift
+class Teacher() extends Person {
+    def override_work(): Unit = {
+        println("Teach in a classroom. ")
+        waitLabel(Turn, 1)
+    }
+
+    def main(): Unit = {
+        while (true) {
+            work()
+            waitAndReply(1)
+        }
+    }
+}
+
+class lifterTest3 extends FlatSpec {
+    import meta.deep.IR.Predef._
+    import meta.classLifting.Lifter
+
+    "Lifting agents with overriding keywords" should "compile" in {
+        val workerClass: ClassWithObject[Worker] = Worker.reflect(IR)
+        val teacherClass: ClassWithObject[Teacher] = Teacher.reflect(IR)
+
+        val liftedMain = meta.classLifting.liteLift {
+            def apply(): List[Actor] = {
+                val teacher = new Teacher()
+                val worker = new Worker()
+                List(teacher, worker)
+            }
+        }
+
+        compileSims(List(workerClass, teacherClass), 
+            mainInit = Some(liftedMain), 
+            initPkgName = Some(this.getClass().getPackage().getName()+".inheritance"),
+            destFolder = "core/src/test/scala/generated/inheritance/")
+    }
+
+    // "Calling overriden methods" should "invoke local methods" in {
+    //     val agents = generated.meta.test.inheritance.InitData()
+    //     val c = new SimulationConfig(agents, 5)
+    //     val r = StartSimulation[BaseMessagingLayer.type](c)
+    // }
+}

--- a/core/src/test/scala/lifterTest4.scala
+++ b/core/src/test/scala/lifterTest4.scala
@@ -14,7 +14,7 @@ import java.io.File
  */
 
 @lift
-class Student(var teacher: Teacher) extends Person {
+class Student(var neighbor: Teacher) extends Person {
 
     def override_work(): Unit = {
         println("Study at school")
@@ -25,7 +25,8 @@ class Student(var teacher: Teacher) extends Person {
             work()
             // Ask what does the teacher do
             // teacher.work() would invoke Person.work() instead
-            asyncMessage[Unit](() => teacher.override_work())
+            // asyncMessage[Unit](() => neighbor.override_work())
+            asyncMessage[Unit](() => neighbor.work())
             waitAndReply(1)
         }
     }

--- a/core/src/test/scala/lifterTest4.scala
+++ b/core/src/test/scala/lifterTest4.scala
@@ -1,0 +1,62 @@
+package meta.test
+
+import meta.classLifting.SpecialInstructions._
+import squid.quasi.lift
+import meta.deep.IR.TopLevel.ClassWithObject
+import meta.deep.IR
+import meta.runtime.{Actor}
+import meta.API._
+import org.scalatest.FlatSpec
+import java.io.File
+
+/**
+ * Test messaging for override methods
+ */
+
+@lift
+class Student(var teacher: Teacher) extends Person {
+
+    def override_work(): Unit = {
+        println("Study at school")
+    }
+
+    def main(): Unit = {
+        while (true) {
+            work()
+            // Ask what does the teacher do
+            // teacher.work() would invoke Person.work() instead
+            asyncMessage[Unit](() => teacher.override_work())
+            waitAndReply(1)
+        }
+    }
+}
+
+class lifterTest4 extends FlatSpec {
+    import meta.deep.IR.Predef._
+    import meta.classLifting.Lifter
+
+    // "Calling an override method from another agent" should "invoke the right function" in {
+        
+    //     val teacherClass: ClassWithObject[Teacher] = Teacher.reflect(IR)
+    //     val studentClass: ClassWithObject[Student] = Student.reflect(IR)
+
+    //     val liftedMain = meta.classLifting.liteLift {
+    //         def apply(): List[Actor] = {
+    //             val teacher = new Teacher()
+    //             val student = new Student(teacher)
+    //             List(teacher, student)
+    //         }
+    //     }
+
+    //     compileSims(List(teacherClass, studentClass), 
+    //         mainInit = Some(liftedMain), 
+    //         initPkgName = Some(this.getClass().getPackage().getName()+".inheritance2"),
+    //         destFolder = "core/src/test/scala/generated/inheritance2/")
+    // }
+
+    "Calling a remote overriden method" should "invoke the child method" in {
+        val agents = generated.meta.test.inheritance2.InitData()
+        val c = new SimulationConfig(agents, 5)
+        val r = StartSimulation[BaseMessagingLayer.type](c)
+    }
+}

--- a/core/src/test/scala/lifterTest4.scala
+++ b/core/src/test/scala/lifterTest4.scala
@@ -23,8 +23,9 @@ class Student(var neighbor: Teacher) extends Person {
     def main(): Unit = {
         while (true) {
             work()
-            // Ask what does the teacher do
-            // teacher.work() would invoke Person.work() instead
+            // Ask what does the neighbor do
+            // Due to bind time analysis, if neighbor is of type Person, then will crash
+            // worker.work() would invoke Person.work() instead
             // asyncMessage[Unit](() => neighbor.override_work())
             asyncMessage[Unit](() => neighbor.work())
             waitAndReply(1)

--- a/core/src/test/scala/liteLiftTest.scala
+++ b/core/src/test/scala/liteLiftTest.scala
@@ -1,4 +1,4 @@
-package meta.test.liteLift
+package meta.test
 
 import scala.collection.mutable.ListBuffer
 import org.scalatest.{Matchers, FlatSpec}

--- a/example/src/main/scala/example/graphAlgorithm/shortestPath/Example.scala
+++ b/example/src/main/scala/example/graphAlgorithm/shortestPath/Example.scala
@@ -11,9 +11,9 @@ object MainInit {
         def apply(n: Int, p: Double): List[Actor] = {
             val allAgents: List[Vertex] = 1.to(n).map(i => {
                 if (i == n/2) {
-                    new Vertex(true)
+                    new Vertex(true, 1)
                 } else {
-                    new Vertex(false)
+                    new Vertex(false, 1)
                 }
             }).toList
 
@@ -22,7 +22,6 @@ object MainInit {
                     x !=vertex && p>Random.nextDouble()
                 })
                 vertex.connectedAgents = nodes
-                vertex.outEdgeWeights = (1 to nodes.length).map(_=>1).toList
             }
 
             (new Graph).build[Vertex](allAgents, built)

--- a/example/src/main/scala/example/graphAlgorithm/shortestPath/Vertex.scala
+++ b/example/src/main/scala/example/graphAlgorithm/shortestPath/Vertex.scala
@@ -6,11 +6,9 @@ import squid.quasi.lift
 
 // Single-source shortest path
 @lift
-class Vertex(val isSource: Boolean) extends Actor {
+class Vertex(val isSource: Boolean, val uniformEdgeWeight: Int) extends Actor {
     var dist: Int = scala.Int.MaxValue
     var propagateUpdate: Boolean = false
-
-    var outEdgeWeights: List[Int] = null
     private var futures: List[Future[Boolean]] = null
     private var tmp_neighbor: Vertex = null
     private var broadcastDist: Int = scala.Int.MaxValue
@@ -33,9 +31,9 @@ class Vertex(val isSource: Boolean) extends Actor {
 
         while (true) {
             if (propagateUpdate){
-                futures = outEdgeWeights.zipWithIndex.map(x => {
-                    broadcastDist = dist + x._1
-                    tmp_neighbor = connectedAgents(x._2).asInstanceOf[Vertex]
+                futures = connectedAgents.map(x => {
+                    broadcastDist = dist + uniformEdgeWeight
+                    tmp_neighbor = x.asInstanceOf[Vertex]
                     asyncMessage(() => tmp_neighbor.updateValue(broadcastDist))
                 })
                 while (futures.exists(x => !x.isCompleted)){

--- a/generated/src/test/scala/graphAlgTest.scala
+++ b/generated/src/test/scala/graphAlgTest.scala
@@ -2,26 +2,52 @@ package generated.example.test
 
 import meta.API._
 import meta.runtime.{Actor}
+import java.io._
 
 class shortestPathTest extends org.scalatest.FlatSpec {
-    "Compiled shortest path example with 10 nodes" should "run" in {
-        val agents = generated.example.graphAlgorithm.shortestPath.InitData(100, 0.1)
-        // println(agents.map(x => x.asInstanceOf[generated.example.graphAlgorithm.shortestPath.Vertex].neighbors.size))
+    val totalVertices = 100
+    val agents = generated.example.graphAlgorithm.shortestPath.InitData(totalVertices, 0.1)
+    val total_diff = (x: List[Int], y: List[Int]) => (0 until totalVertices).filter {
+        i => x(i) != y(i)
+    }.length 
 
-        type MapperOut = (Long, Int)
-        type ReducerOut = List[Int]
+    type MapperOut = (Long, Int)
+    type ReducerOut = List[Int]
 
-        // record the shortest distance from each vertex to the single source
-        val mapper: Actor => MapperOut = (agent) => (agent.id, agent.asInstanceOf[generated.example.graphAlgorithm.shortestPath.Vertex].dist)
+    // record the shortest distance from each vertex to the single source
+    val mapper: Actor => MapperOut = (agent) => (agent.id, agent.asInstanceOf[generated.example.graphAlgorithm.shortestPath.Vertex].dist)
 
-        val reducer: List[MapperOut] => ReducerOut = (x) => x.sortWith((s, t) => s._1 < t._1).map(a => a._2)
+    val reducer: List[MapperOut] => ReducerOut = (x) => x.sortWith((s, t) => s._1 < t._1).map(a => a._2)
 
-        val c = new SimulationConfig(agents, 5)
-        // val containerConfig = c.staticPartition(10)(BoundedLatency)
-        val results = StartSimulation.runAndReduce[AkkaMessagingLayer.type, MapperOut, ReducerOut](c)(mapper, reducer)
+    val totalRounds = 10
 
-        // val results = StartSimulation[AkkaMessagingLayer.type](c)
-        results.foreach(println)
+    "Reset vertices in shortest path" should "obtain the same results" in {
+        val c = new SimulationConfig(agents, totalRounds)
+
+        val results: List[List[Int]] = StartSimulation.runAndReduce[AkkaMessagingLayer.type, MapperOut, ReducerOut](c)(mapper, reducer)
+
+        val resultsTail = results.tail
+        // val pw = new PrintWriter(new FileOutputStream(new File("shortestPath.csv"),false))
+        // results.foreach(x => pw.write(x))
+        
+        val measured_diffs = (0 until totalRounds-1).map(i => {
+            total_diff(results(i), resultsTail(i))
+        })
+
+        agents.foreach(a => a.SimReset())
+        val c2 = new SimulationConfig(agents, totalRounds)
+        
+        val results2: List[List[Int]] = StartSimulation.runAndReduce[AkkaMessagingLayer.type, MapperOut, ReducerOut](c2)(mapper, reducer)
+
+        val resultsTail2 = results2.tail
+        
+        val measured_diffs2 = (0 until totalRounds-1).map(i => {
+            total_diff(results2(i), resultsTail2(i))
+        })
+
+        // println(measured_diffs)
+        // println(measured_diffs2)
+        assert(measured_diffs == measured_diffs2)
     }
 }
 

--- a/generated/src/test/scala/staticPartitionWJIT.scala
+++ b/generated/src/test/scala/staticPartitionWJIT.scala
@@ -1,0 +1,67 @@
+package generated.example.test
+
+import meta.API._
+import scala.collection.mutable.{Map}
+import java.io._
+import meta.runtime.Actor
+
+/**
+* Reset objects between benchmark phases. 
+* Can trigger unexpected JIT optimization for long-running workloads. 
+* Only apply for graph anayltics workload which run for few iterations
+*/
+class StaticPartitionTestWJIT[T: SimsRunner](name: String, 
+                    totalTurns: Int,
+                    latencys: Set[Int],
+                    containers: Set[Int],
+                    parameterss: Traversable[Traversable[Any]], 
+                    init: => List[Any] => List[Actor], 
+                    schemaWriter: => PrintWriter => Unit) extends org.scalatest.FlatSpec {
+
+    def run(): Unit = {
+        val output: String = f"${name}.csv"
+        val pw = new PrintWriter(new FileOutputStream(new File(output),false))
+
+        pw.write("Experiment,Containers,K,AvgTime,")
+        schemaWriter(pw)
+        pw.write("\n")
+
+        Util.crossJoin(parameterss).foreach(x => {
+            val agents = init(x.toList)
+
+            for (container <- containers; latency <- latencys){
+                agents.foreach(x => x.SimReset)
+                val c = new SimulationConfig(agents, totalTurns, true, latency)
+                val avgTime = {
+                    if (container == 0){
+                        StartSimulation.benchAvg[T](c)
+                    }else {
+                        val containerConfig = c.staticPartition(container)(BoundedLatency)
+                        StartSimulation.benchAvg[T](containerConfig)
+                    }
+                } 
+                pw.write(f"\n${name},${container},${latency},${avgTime},${Util.csList(x)}")
+                pw.flush()
+            }
+        })
+        pw.close()
+    }
+
+    f"${name} example with ${containers} containers with latency bound ${latencys} in Akka" should "run" in {
+        run()
+    }
+}
+
+class shortestPathStaticTestWJITAkka extends StaticPartitionTestWJIT[AkkaMessagingLayer.type](
+    "shortestPath", 3, Set(1), Set(10, 50, 100, 500, 1000), 
+    List(Set(1000, 10000, 100000), Set(0.001)), 
+    generated.example.graphAlgorithm.shortestPath.InitData.wrapper, 
+    generated.example.graphAlgorithm.shortestPath.InitData.writeSchema) {
+}
+
+class pageRankStaticTestWJITAkka extends StaticPartitionTestWJIT[AkkaMessagingLayer.type](
+    "pageRank", 20, Set(1, 4), Set(10, 50, 100, 500, 1000), 
+    List(Set(1000, 10000), Set(0.001)), 
+    generated.example.graphAlgorithm.pageRank.InitData.wrapper, 
+    generated.example.graphAlgorithm.pageRank.InitData.writeSchema) {
+}


### PR DESCRIPTION
- Generating a large graph takes long time. Reuse objects between experiments by resetting their values but preserving the connectivity
- Encode override modifier with override_ prefix and add examples (lifterTest3, lifterTest4)